### PR TITLE
fix: Fix `customerV2` index schema

### DIFF
--- a/pkg/store/subscription/aws/store.go
+++ b/pkg/store/subscription/aws/store.go
@@ -58,10 +58,6 @@ var DynamoSubscriptionTableProps = struct {
 					AttributeName: aws.String("provider"),
 					KeyType:       types.KeyTypeRange,
 				},
-				{
-					AttributeName: aws.String("subscription"),
-					KeyType:       types.KeyTypeRange,
-				},
 			},
 			Projection: &types.Projection{
 				ProjectionType: types.ProjectionTypeAll,


### PR DESCRIPTION
I don't really understand this code, I just know that Dynamo complained until Claude told me this part was wrong and unnecessary. Can anyone confirm? I couldn't run Sprue at all without this change.